### PR TITLE
Fix bugs and performance issues from code review

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,10 +61,10 @@ let defaultForProvider;
 // Use whatever model is set for the selected provider (env or default).
 if (resolvedProvider === 'gemini') {
   defaultForProvider = DEFAULT_GEMINI_MODEL;
-  resolvedModel = envGeminiModel || envOpenaiModel || defaultForProvider;
+  resolvedModel = envGeminiModel || defaultForProvider;
 } else if (resolvedProvider === 'claude') {
   defaultForProvider = DEFAULT_CLAUDE_MODEL;
-  resolvedModel = envClaudeModel || envOpenaiModel || defaultForProvider;
+  resolvedModel = envClaudeModel || defaultForProvider;
 } else {
   resolvedModel = envOpenaiModel || DEFAULT_MODEL;
 }

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -378,8 +378,11 @@ module.exports = {
 
       // Add bot's previous response if replying to bot (use fetched parent, not the current user message).
       if (isReplyToBot && botReferencedMessage) {
-        const lastAssistant = [...channelHistory].reverse().find(m => m.role === 'assistant');
-        if (!lastAssistant || lastAssistant.content !== botReferencedMessage.content) {
+        const lastAssistant = channelHistory.findLast(m => m.role === 'assistant');
+        if (!lastAssistant || (
+          lastAssistant.content !== botReferencedMessage.content &&
+          !lastAssistant.content.startsWith(botReferencedMessage.content)
+        )) {
           logger.debug(`Adding bot's previous response to conversation history for channel ${channelId}.`);
           channelHistory.push({
             role: 'assistant',

--- a/utils/aiService.js
+++ b/utils/aiService.js
@@ -60,6 +60,7 @@ const anthropic = anthropicApiKey ? new Anthropic({ apiKey: anthropicApiKey }) :
 
 /** In-memory Gemini context cache: one entry for system instruction (reused across channels). */
 let geminiCacheEntry = null;
+let geminiCacheCreating = false;
 
 /** Claude model IDs that support extended thinking (4.x family). */
 const CLAUDE_EXTENDED_THINKING_MODELS = [
@@ -274,7 +275,8 @@ async function generateGeminiResponse(conversation) {
     if (geminiCacheEntry && geminiCacheEntry.systemInstruction === systemWithImageHint && geminiCacheEntry.expiresAt > now) {
       config.cachedContent = geminiCacheEntry.name;
       useCachedContent = true;
-    } else {
+    } else if (!geminiCacheCreating) {
+      geminiCacheCreating = true;
       try {
         const cache = await genAI.caches.create({
           model: modelName,
@@ -294,6 +296,8 @@ async function generateGeminiResponse(conversation) {
           message: cacheErr?.message
         });
         config.systemInstruction = systemWithImageHint;
+      } finally {
+        geminiCacheCreating = false;
       }
     }
   }
@@ -434,7 +438,7 @@ async function generateClaudeResponse(conversation) {
     }
   }
 
-  if (claudeThinkingBudgetTokens > 0 && claudeSupportsExtendedThinking(modelName)) {
+  if (claudeThinkingBudgetTokens > 0 && claudeThinkingBudgetTokens < maxOutputTokens && claudeSupportsExtendedThinking(modelName)) {
     params.thinking = { type: 'enabled', budget_tokens: claudeThinkingBudgetTokens };
   }
 
@@ -565,12 +569,11 @@ async function generateOpenAIResponse(conversation) {
 
     const temperature = getTemperature();
     requestParams.temperature = temperature;
-    const temperatureValue = temperature;
 
     logger.debug(`Sending conversation to OpenAI API using model ${modelName}.`, {
       messageCount: conversation.length,
       model: modelName,
-      temperature: temperatureValue,
+      temperature,
       reasoningEffort: normalizedReasoningEffort || undefined,
       verbosity: normalizedVerbosity || undefined,
       webSearch: enableWebSearch,

--- a/utils/aiUtils.js
+++ b/utils/aiUtils.js
@@ -196,20 +196,7 @@ function findBestSplitPoint(text, limit) {
  * @returns {number} The position of the last occurrence, or -1 if not found
  */
 function findLastOccurrence(text, searchStr, maxPos) {
-  const searchLength = searchStr.length;
-  let lastPos = -1;
-  let pos = 0;
-  
-  while (pos < maxPos) {
-    const foundPos = text.indexOf(searchStr, pos);
-    if (foundPos === -1 || foundPos >= maxPos) {
-      break;
-    }
-    lastPos = foundPos;
-    pos = foundPos + searchLength;
-  }
-  
-  return lastPos;
+  return text.lastIndexOf(searchStr, maxPos - 1);
 }
 
 /**
@@ -496,19 +483,14 @@ function pruneConversationHistories(conversationHistory, channelLastActivity, ma
 
   if (typeof maxChannels !== 'number' || maxChannels <= 0 || !channelLastActivity) return;
 
-  while (conversationHistory.size > maxChannels) {
-    let oldestChannelId = null;
-    let oldestActivity = Infinity;
-    for (const channelId of conversationHistory.keys()) {
-      const lastActive = channelLastActivity.get(channelId) ?? 0;
-      if (lastActive < oldestActivity) {
-        oldestActivity = lastActive;
-        oldestChannelId = channelId;
-      }
+  if (conversationHistory.size > maxChannels) {
+    const overflow = conversationHistory.size - maxChannels;
+    const sorted = [...conversationHistory.keys()]
+      .sort((a, b) => (channelLastActivity.get(a) ?? 0) - (channelLastActivity.get(b) ?? 0));
+    for (let i = 0; i < overflow; i++) {
+      conversationHistory.delete(sorted[i]);
+      channelLastActivity.delete(sorted[i]);
     }
-    if (!oldestChannelId) break;
-    conversationHistory.delete(oldestChannelId);
-    channelLastActivity.delete(oldestChannelId);
   }
 }
 

--- a/utils/replyChainTracer.js
+++ b/utils/replyChainTracer.js
@@ -8,6 +8,9 @@ const DEFAULT_MAX_CHAIN_DEPTH = 15;
 /** Cache for fetched messages to avoid duplicate API calls. */
 const MESSAGE_CACHE = new Map();
 
+/** Timestamp of last full TTL-expiry scan (rate-limits the O(n) walk). */
+let messageCacheLastTrimAt = 0;
+
 /**
  * Clear the message cache (useful for testing or manual cache clearing)
  */
@@ -17,18 +20,21 @@ function clearCache() {
 
 /**
  * Remove expired entries and enforce LRU capacity.
+ * TTL scan is rate-limited to at most once every 30 s to avoid O(n) work on every write.
+ * Size cap is always enforced.
  */
 function trimMessageCache() {
   const now = Date.now();
-  for (const [key, entry] of MESSAGE_CACHE) {
-    if (entry.expiresAt <= now) {
-      MESSAGE_CACHE.delete(key);
+  if (now - messageCacheLastTrimAt >= 30_000) {
+    messageCacheLastTrimAt = now;
+    for (const [key, entry] of MESSAGE_CACHE) {
+      if (entry.expiresAt <= now) {
+        MESSAGE_CACHE.delete(key);
+      }
     }
   }
-
   while (MESSAGE_CACHE.size > messageCacheMaxSize) {
-    const oldestKey = MESSAGE_CACHE.keys().next().value;
-    MESSAGE_CACHE.delete(oldestKey);
+    MESSAGE_CACHE.delete(MESSAGE_CACHE.keys().next().value);
   }
 }
 
@@ -57,6 +63,8 @@ async function fetchMessageCached(channel, messageId) {
   const cached = MESSAGE_CACHE.get(cacheKey);
   if (cached) {
     if (cached.expiresAt > Date.now()) {
+      MESSAGE_CACHE.delete(cacheKey);
+      MESSAGE_CACHE.set(cacheKey, cached);
       return cached.message;
     }
     MESSAGE_CACHE.delete(cacheKey);


### PR DESCRIPTION
- config: remove cross-provider model name fallback (GEMINI/CLAUDE no longer
  fall back to OPENAI_MODEL_NAME, preventing confusing startup crashes)
- aiService: guard Claude extended thinking so budget_tokens < max_tokens,
  preventing 400 errors when thinking budget meets or exceeds output limit
- aiService: add geminiCacheCreating flag to prevent concurrent requests from
  each creating a duplicate Gemini context cache
- aiService: remove dead temperatureValue alias in OpenAI request path
- messageCreate: fix duplicate-assistant-message guard to use startsWith so
  split responses (first Discord chunk vs full stored reply) no longer inject
  a phantom assistant turn into channel history on every chained reply
- messageCreate: replace spread+reverse+find with Array.findLast (Node >=24)
- replyChainTracer: make cache eviction truly LRU by re-inserting entries on
  read to update Map insertion order
- replyChainTracer: rate-limit TTL expiry scan to at most once per 30 s
  instead of O(n) on every write (size cap still enforced on every write)
- aiUtils: replace O(n²) LRU eviction loop in pruneConversationHistories with
  a single O(n log n) sorted pass
- aiUtils: replace findLastOccurrence manual loop with String.lastIndexOf

https://claude.ai/code/session_0149F8d5PoKa7TJQ8iCDzHZ5